### PR TITLE
Added support for objects of prepositions

### DIFF
--- a/lib/linkparser/linkage.rb
+++ b/lib/linkparser/linkage.rb
@@ -241,6 +241,25 @@ class LinkParser::Linkage
 	end
 
 
+  ### Return the object of the preposition in the linkage.
+  def object_of_preposition
+    objlink = self.links.find {|link| link.rlabel[0] == ?J } or return nil
+    if objlink.length > 1
+      # Check if the prepositional object contains a modifier.
+      modifier_structs = self.links.find_all {|link| link.rlabel[0] == ?A } 
+      if modifier_structs.empty?
+        return objlink.rword.sub( /\.[n](?:-\w)?$/, '' )
+      end
+      modifiers = []
+      modifier_structs.each do |modifier_struct|
+        modifiers << modifier_struct.lword.sub( /\.(a|n)?/, '' )
+      end
+      modifiers.unshift(modifier_structs.first.rword.sub( /\.(a|n)?/, '' ))
+      return modifiers.reverse.join(' ')
+    end
+  end
+
+
 	### Return an Array of all the nouns in the linkage.
 	def nouns
 		nouns = []

--- a/lib/linkparser/linkage.rb
+++ b/lib/linkparser/linkage.rb
@@ -244,17 +244,18 @@ class LinkParser::Linkage
   ### Return the object of the preposition in the linkage.
   def object_of_preposition
     objlink = self.links.find {|link| link.rlabel[0] == ?J } or return nil
-    if objlink.length > 1
-      # Check if the prepositional object contains a modifier.
-      modifier_structs = self.links.find_all {|link| link.rlabel[0] == ?A } 
-      if modifier_structs.empty?
-        return objlink.rword.sub( /\.[n](?:-\w)?$/, '' )
-      end
+    # Check if the prepositional object contains a modifier.
+    modlinks = self.links.find_all {|link| link.rlabel[0] == ?A } 
+    if modlinks.empty?
+      # No modifiers
+      return objlink.rword.sub( /\.[n](?:-\w)?$/, '' )
+    else
+      # At least one modifier
       modifiers = []
-      modifier_structs.each do |modifier_struct|
-        modifiers << modifier_struct.lword.sub( /\.(a|n)?/, '' )
+      modlinks.each do |modlink|
+        modifiers << modlink.lword.sub( /\.(a|n)?/, '' )
       end
-      modifiers.unshift(modifier_structs.first.rword.sub( /\.(a|n)?/, '' ))
+      modifiers.unshift(modlinks.first.rword.sub( /\.(a|n)?/, '' ))
       return modifiers.reverse.join(' ')
     end
   end

--- a/spec/linkparser/linkage_spec.rb
+++ b/spec/linkparser/linkage_spec.rb
@@ -371,6 +371,30 @@ describe LinkParser::Linkage do
 	end
 
 
+  context "when parsing a simple sentence" do
+    it "returns the object of the preposition" do
+      # This depends on the linkage:
+      #    +------------------Xp-----------------+
+      #    |                      +----Js---+    |
+      #    +--Wd--+--Sp*i-+--MVp--+   +--Ds-+    |
+      #    |      |       |       |   |     |    |
+      #    LEFT-WALL I.p jumped.v-d over the couch.n .
+      sentence = @dict.parse("I jumped over the couch.")
+      sentence.object_of_preposition.should == 'couch'
+    end
+    it "returns the entire prepositional object with modifiers" do
+      # This depends on the linkage:
+      #    +----------------------------Xp---------------------------+
+      #    |                      +-------------Jp------------+      |
+      #    +--Wd--+--Sp*i-+--MVp--+      +----A----+----AN----+      |
+      #    |      |       |       |      |         |          |      |
+      #    LEFT-WALL I.p jumped.v-d over Las[?].a Vegas[?].n County[?].n . 
+      sentence = @dict.parse("I jumped over Las Vegas County.")
+      sentence.object_of_preposition.should == 'Las[?] Vegas[?] County[?]'
+    end
+  end
+
+
 	context "deprecated sublinkage API" do
 
 		before( :each ) do


### PR DESCRIPTION
Calling sent.object_of_preposition now returns the full object of the preposition.

"I jumped over the couch." => "couch"
"I jumped over Las Vegas County." => "Las Vegas County"

I also wrote simple tests for those cases.
